### PR TITLE
THREE.Silk: Fixed old THREE.Renderers.Shaders, wrong method calls and incorrect interface reference

### DIFF
--- a/THREE.Silk/Extensions/UniformsExtensions.cs
+++ b/THREE.Silk/Extensions/UniformsExtensions.cs
@@ -1,12 +1,6 @@
 ﻿using Silk.NET.OpenGLES;
-using System;
 using System.Collections;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
-using THREE.Renderers.Shaders;
 
 namespace THREE
 {

--- a/THREE.Silk/Postprocessing/BloomPass.cs
+++ b/THREE.Silk/Postprocessing/BloomPass.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections;
-using THREE.Renderers.Shaders;
+﻿using System.Collections;
 
 namespace THREE
 {

--- a/THREE.Silk/Postprocessing/BokehPass.cs
+++ b/THREE.Silk/Postprocessing/BokehPass.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections;
-using THREE.Renderers.Shaders;
+﻿using System.Collections;
 
 namespace THREE
 {

--- a/THREE.Silk/Postprocessing/DotScreenPass.cs
+++ b/THREE.Silk/Postprocessing/DotScreenPass.cs
@@ -1,8 +1,4 @@
-﻿
-using System;
-using THREE.Renderers.Shaders;
-
-namespace THREE
+﻿namespace THREE
 {
     [Serializable]
     public class DotScreenPass : Pass

--- a/THREE.Silk/Postprocessing/FilmPass.cs
+++ b/THREE.Silk/Postprocessing/FilmPass.cs
@@ -1,8 +1,4 @@
-﻿
-using System;
-using THREE.Renderers.Shaders;
-
-namespace THREE
+﻿namespace THREE
 {
     [Serializable]
     public class FilmPass : Pass

--- a/THREE.Silk/Postprocessing/GlitchPass.cs
+++ b/THREE.Silk/Postprocessing/GlitchPass.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Drawing;
-using System.Drawing.Imaging;
-using System.Runtime.InteropServices;
-using THREE.Renderers.Shaders;
-
-namespace THREE
+﻿namespace THREE
 {
     [Serializable]
     public class GlitchPass : Pass

--- a/THREE.Silk/Postprocessing/HalftonePass.cs
+++ b/THREE.Silk/Postprocessing/HalftonePass.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections;
-using THREE.Renderers.Shaders;
+﻿using System.Collections;
 
 namespace THREE
 {

--- a/THREE.Silk/Postprocessing/OutlinePass.cs
+++ b/THREE.Silk/Postprocessing/OutlinePass.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
-using THREE.Renderers.Shaders;
+﻿using System.Collections;
 
 namespace THREE
 {

--- a/THREE.Silk/Postprocessing/SSAOPass.cs
+++ b/THREE.Silk/Postprocessing/SSAOPass.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Drawing;
-using System.Drawing.Imaging;
-using System.Runtime.InteropServices;
-using THREE.Renderers.Shaders;
+﻿using System.Collections;
 
 namespace THREE
 {

--- a/THREE.Silk/Postprocessing/ShaderPass.cs
+++ b/THREE.Silk/Postprocessing/ShaderPass.cs
@@ -1,8 +1,4 @@
-﻿
-using System;
-using THREE.Renderers.Shaders;
-
-namespace THREE
+﻿namespace THREE
 {
     [Serializable]
     public class ShaderPass : Pass

--- a/THREE.Silk/Postprocessing/TexturePass.cs
+++ b/THREE.Silk/Postprocessing/TexturePass.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using THREE.Renderers.Shaders;
-
-namespace THREE
+﻿namespace THREE
 {
     [Serializable]
     public class TexturePass : Pass

--- a/THREE.Silk/Postprocessing/UnrealBloomPass.cs
+++ b/THREE.Silk/Postprocessing/UnrealBloomPass.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
-using THREE.Renderers.Shaders;
+﻿using System.Collections;
 
 namespace THREE
 {

--- a/THREE.Silk/Renderers/GLRenderer.cs
+++ b/THREE.Silk/Renderers/GLRenderer.cs
@@ -538,7 +538,7 @@ namespace THREE
 
             //
 
-            if (index != null && index.Count == 0) return;
+            if (index != null && index.count == 0) return;
             //if (position != null || position.count === 0) return;
             if (position == null) return;
 

--- a/THREE.Silk/Renderers/gl/GLBindingStates.cs
+++ b/THREE.Silk/Renderers/gl/GLBindingStates.cs
@@ -511,7 +511,7 @@ namespace THREE
                                     {
 
 
-                                        (geometry as InstancedBufferGeometry).MaxInstanceCount = (data as InstancedInterleavedBuffer<float>).MeshPerAttribute * (data as InstancedInterleavedBuffer<float>).Count;
+                                        (geometry as InstancedBufferGeometry).MaxInstanceCount = (data as InstancedInterleavedBuffer<float>).MeshPerAttribute * (data as InstancedInterleavedBuffer<float>).count;
 
                                     }
                                 }

--- a/THREE.Silk/Renderers/gl/GLPrograms.cs
+++ b/THREE.Silk/Renderers/gl/GLPrograms.cs
@@ -279,7 +279,7 @@ namespace THREE
 
             parameters.Add("vertexColors", material.VertexColors);
 
-            parameters.Add("vertexAlphas", material.VertexColors && object3D.Geometry != null && object3D.Geometry is BufferGeometry && (object3D.Geometry as BufferGeometry).Attributes["color"] != null && ((object3D.Geometry as BufferGeometry).Attributes["color"] as IGLAttribute).ItemSize == 4);
+            parameters.Add("vertexAlphas", material.VertexColors && object3D.Geometry != null && object3D.Geometry is BufferGeometry && (object3D.Geometry as BufferGeometry).Attributes["color"] != null && ((object3D.Geometry as BufferGeometry).Attributes["color"] as IBufferAttribute).ItemSize == 4);
 
             parameters.Add("vertexUvs", material.Map != null || material.BumpMap != null || material.NormalMap != null || material.SpecularMap != null || material.AlphaMap != null || material.EmissiveMap != null || material.RoughnessMap != null || material.MetalnessMap != null || material.ClearcoatNormalMap != null);
 

--- a/THREE.Silk/Renderers/gl/GLShadowMap.cs
+++ b/THREE.Silk/Renderers/gl/GLShadowMap.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections;
 using System.Diagnostics;
-using THREE.Renderers.Shaders;
 
 namespace THREE
 {


### PR DESCRIPTION
Related to: https://github.com/hjoykim/THREE/issues/51#issuecomment-2878910328.

- I still get a `System.Exception: 'THREE.Renderers.gl.GLProgram: shader error Points, gl.VALIDATE_STATUS 0, gl.GetProgramInfoLog` when starting the `SingleSceneSilkExample` project. I do not require shaders and I am way out of my depth with this so I am leaving this to someone else to fix. If I'll ever get around to it I'll do another pull request.